### PR TITLE
Properly toggle Projects link in header

### DIFF
--- a/layouts/partials/sections/header.html
+++ b/layouts/partials/sections/header.html
@@ -83,7 +83,7 @@
                     {{
                     if and
                     (.Site.Params.projects.enable | default false)
-                    (not (.Site.Params.navbar.menus.disableEducation | default false))
+                    (not (.Site.Params.navbar.menus.disableProjects | default false))
                     }}
                     {{/* {{ if .Site.Params.projects.enable | default false }} */}}
                     <li class="nav-item navbar-text">


### PR DESCRIPTION
The Projects link in the header was incorrectly using the `disableEducation` parameter rather than the `disableProjects` parameter.