### PR TITLE
Only include GPA when it's specified

### DIFF
--- a/layouts/partials/sections/education.html
+++ b/layouts/partials/sections/education.html
@@ -35,12 +35,14 @@
                                 {{ .school.name }}
                                 {{ end }}
 
+                                {{ if .GPA }}
                                 <div class="py-1">
                                     GPA:
                                     <i>
                                         <small>{{ .GPA }}</small>
                                     </i> 
                                 </div>
+                                {{ end }}
                                 <div class="py-1 education-content">
                                     {{ .content | markdownify}}
                                 </div>


### PR DESCRIPTION
Some people may want to only include the GPA when it's specified. This pull request wraps the displaying of the GPA in a conditional so that when it's an empty string it's not shown on the website.