### PR TITLE
Added animation toggle option

### DIFF
--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -55,6 +55,9 @@ params:
   # Note the lack of "" in true, it should be of boolean type.
   useBootstrapCDN: false
 
+  # Whether the fade animations on the home page will be enabled
+  animate: true
+
   theme:
     disableThemeToggle: false
     # defaultTheme: "light" # dark

--- a/layouts/partials/sections/header.html
+++ b/layouts/partials/sections/header.html
@@ -24,7 +24,7 @@
 
 <!-- Navbar -->
 <header>
-    <nav class="pt-3 navbar navbar-expand-lg">
+    <nav class="pt-3 navbar navbar-expand-lg {{ if .Site.Params.animate }}animate{{ end }}">
         <div class="container-fluid mx-xs-2 mx-sm-5 mx-md-5 mx-lg-5">
             <!-- navbar brand -->
             <a class="navbar-brand primary-font text-wrap" href="{{ .Site.BaseURL | relURL }}">

--- a/layouts/partials/sections/hero/index.html
+++ b/layouts/partials/sections/hero/index.html
@@ -2,7 +2,7 @@
 <section id="hero" class="py-5 align-middle">
     <div class="container px-3 px-sm-5 px-md-5 px-lg-5 pt-lg-3">
         <div class="row">
-            <div class="col-sm-12 col-md-12 col-lg-8 content" id="primary-font">
+            <div class="col-sm-12 col-md-12 col-lg-8 content {{ if .Site.Params.animate }}animate{{ end }}" id="primary-font">
                 <span class="subtitle">
                     {{ .Site.Params.hero.intro }}
                 </span>
@@ -30,7 +30,7 @@
             </div>
             <div class="col-sm-12 col-md-12 col-lg-4">
                 <div class="row justify-content-center">
-                    <div class="col-sm-12 col-md-9 pt-5 image px-5 px-md-5 px-lg-0 text-center">
+                    <div class="col-sm-12 col-md-9 pt-5 image {{ if .Site.Params.animate }}animate{{ end }} px-5 px-md-5 px-lg-0 text-center">
                         <img src="{{ .Site.Params.hero.image }}" 
                             class="img-thumbnail mx-auto" 
                             alt=""

--- a/layouts/partials/sections/hero/social.html
+++ b/layouts/partials/sections/hero/social.html
@@ -1,4 +1,4 @@
-<span id="loading-icons" style="display: none;">
+<span id="loading-icons" style="display: {{ if .Site.Params.animate }}none{{else}}block{{ end }};">
     {{ range .Site.Params.hero.socialLinks.fontAwesomeIcons }}
     <span class="px-1">
         <a href="{{ .url }}" target="_blank" class="btn social-icon">

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -51,9 +51,10 @@
   }
 }
 
-header .navbar {
+header .navbar.animate {
     animation: fade-up 0.5s ease-in;
 }
+
 
 /* ToolTip */
 
@@ -75,7 +76,7 @@ header .navbar {
     line-height: 2rem;
     max-width: 100%;
 }
-#hero .content {
+#hero .content.animate {
     animation: fade-left 1s ease-out;
 }
 
@@ -108,7 +109,7 @@ header .navbar {
     opacity: 0.8;
 }
 
-#hero .image img {
+#hero .image.animate img {
     animation: fade-in 1s ease-out;
     box-shadow: 0px 8px 56px rgba(15, 80, 100, 0.16);
     transition: box-shadow 0.3s;


### PR DESCRIPTION
Hi, I added a toggle option in the config file which toggles whether the fading animations (enabled by default) should be applied on the home page or not. 

How it works: I changed `index.css` so that the `animation` properties are only applied to elements that also have the class `.animate`. Then in the template files, I conditionally applied the `.animate` class to the animated elements only if the config option is enabled. Also, I set the social media icons to have `display: block` by default if the animate option is disabled, so there is no delay before they appear.