### PR TITLE
Optionally open resume in a new tab

### DIFF
--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -112,6 +112,7 @@ params:
       name: "Resume"
       url: "#"
       download: true
+      newPage: true
     socialLinks:
       fontAwesomeIcons:
         - icon: fab fa-github

--- a/layouts/partials/sections/hero/index.html
+++ b/layouts/partials/sections/hero/index.html
@@ -18,7 +18,10 @@
                 <div class="row">
                     <div class="col-auto h-100">
                         {{ if .Site.Params.hero.button.enable }}
-                        <a href="{{ .Site.Params.hero.button.url }}" class="btn" {{ cond .Site.Params.hero.button.download "download" "" }}>
+                        <a href="{{ .Site.Params.hero.button.url }}" class="btn" {{ cond .Site.Params.hero.button.download "download" "" }}
+			  {{ if .Site.Params.hero.button.newPage | default true }}
+                          target="_blank"
+                          {{ end }}>
                             {{ .Site.Params.hero.button.name }}
                         </a>
                         {{ end }}


### PR DESCRIPTION
Added an option to open resume in a new tab. This can be turned on/off in config under newPage.