### PR TITLE
feat: add optional response images with cloudinary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@ hugo.darwin
 hugo.linux
 
 # Temporary lock file while building
-/.hugo_build.lock
+.hugo_build.lock

--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -64,6 +64,11 @@ params:
   # Note the lack of "" in true, it should be of boolean type.
   useBootstrapCDN: false
 
+  # If you want to load dynamically responsive images from Cloudinary
+  # This requires your images to be uploaded + hosted on Cloudinary
+  # Uncomment and change YOUR_CLOUD_NAME to the Cloud Name in your Cloudinary console
+  # cloudinary_cloud_name: "YOUR_CLOUD_NAME"
+
   # Whether the fade animations on the home page will be enabled
   animate: true
 

--- a/exampleSite/content/blogs/rich-content.md
+++ b/exampleSite/content/blogs/rich-content.md
@@ -71,5 +71,5 @@ Note that you do not include the file extension (e.g. `.png`) in the `src` param
 Optionally, you can customize the general CSS styles for the image:
 
 ```
-{{</* dynamic-img src="/my/image/on/cloudinary.webp" title="A title for the image" style="max-width:60%" */>}}
+{{</* dynamic-img src="/my/image/on/cloudinary" title="A title for the image" style="max-width:60%" */>}}
 ```

--- a/exampleSite/content/blogs/rich-content.md
+++ b/exampleSite/content/blogs/rich-content.md
@@ -51,3 +51,25 @@ Hugo ships with several [Built-in Shortcodes](https://gohugo.io/content-manageme
 <br>
 {{< youtube w7Ft2ymGmfc >}}
 <br>
+
+## Theme Custom Shortcodes
+
+These shortcodes are not Hugo built-ins, but are provided by the theme.
+
+### Responsive Images with Cloudinary
+
+You can learn more about this [here](https://cloudinary.com/documentation/responsive_images).
+
+Set the `cloudinary_cloud_name` parameter in your site config to use this shortcode.
+
+```
+{{</* dynamic-img src="/my/image/on/cloudinary" title="A title for the image" */>}}
+```
+
+Note that you do not include the file extension (e.g. `.png`) in the `src` parameter, as the shortcode will automatically determine the best quality and format for the user's device.
+
+Optionally, you can customize the general CSS styles for the image:
+
+```
+{{</* dynamic-img src="/my/image/on/cloudinary.webp" title="A title for the image" style="max-width:60%" */>}}
+```

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,6 +1,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta http-equiv="X-UA-Compatible" content="ie=edge">
+<meta http-equiv="Accept-CH" content="DPR, Viewport-Width, Width">
 <link rel="icon" href={{ .Site.Params.favicon | default "/fav.png" }} type="image/gif">
 
 <!-- Fonts -->

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -66,3 +66,14 @@
 {{ if not (.Site.Params.navbar.disableSearch | default false) }}
     <script src="/js/search.js"></script>
 {{ end }}
+
+{{ if (.Site.Params.cloudinary_cloud_name | default false) }}
+
+{{ "<!-- cloudinary -->" | safeHTML }}
+<script src="https://unpkg.com/cloudinary-core@2.13.0/cloudinary-core-shrinkwrap.js" integrity="sha384-0bQduxVhZMs6xfvcPH9osdUIw44hjF8EahHuQBdyN6Rryk8tgyFO80Yz5d14F+5d" crossorigin="anonymous"></script>
+<script type="text/javascript">
+    var cl = cloudinary.Cloudinary.new({cloud_name: "{{- .Site.Params.cloudinary_cloud_name }}"}); 
+    cl.responsive();
+</script>
+
+{{ end }}

--- a/layouts/shortcodes/dynamic-img.html
+++ b/layouts/shortcodes/dynamic-img.html
@@ -9,4 +9,4 @@
 {{ $alt := .Get "title" }}
 {{ $width := .Get "width" | default "w_auto" }}
 {{ $style := .Get "style" | default "max-width:80%" }}
-<img alt="{{ $alt }}" title="{{ $alt }}" data-src="https://res.cloudinary.com/{{ $.Site.Params.cloudinary_cloud_name }}/{{ $width }},c_scale,f_auto,q_auto,dpr_auto{{ $image}}" class="cld-responsive" style="padding-bottom: 1rem; {{ $style }}">
+<img alt="{{ $alt }}" title="{{ $alt }}" data-src="https://res.cloudinary.com/{{ $.Site.Params.cloudinary_cloud_name }}/{{ $width }},c_scale,f_auto,q_auto,dpr_auto{{ $image}}" class="cld-responsive" style="padding-bottom: 16px; {{ $style }}">

--- a/layouts/shortcodes/dynamic-img.html
+++ b/layouts/shortcodes/dynamic-img.html
@@ -3,10 +3,10 @@
     {{< dynamic-img src="/my/image/on/cloudinary.webp" title="A title for the image" >}}
 
     Optionally, you can customize the width or other general styles for the image:
-    {{< dynamic-img src="/my/image/on/cloudinary.webp" title="A title for the image" width="w_auto" style="width:90%" >}}
+    {{< dynamic-img src="/my/image/on/cloudinary.webp" title="A title for the image" width="w_auto" style="max-width:90%" >}}
 -->
 {{ $image := .Get "src" }}
 {{ $alt := .Get "title" }}
 {{ $width := .Get "width" | default "w_auto" }}
-{{ $style := .Get "style" | default "width:90%" }}
+{{ $style := .Get "style" | default "max-width:90%" }}
 <img alt="{{ $alt }}" title="{{ $alt }}" data-src="https://res.cloudinary.com/{{ $.Site.Params.cloudinary_cloud_name }}/{{ $width }},c_scale,f_auto,q_auto,dpr_auto{{ $image}}" class="cld-responsive" style="{{ $style }}">

--- a/layouts/shortcodes/dynamic-img.html
+++ b/layouts/shortcodes/dynamic-img.html
@@ -9,4 +9,4 @@
 {{ $alt := .Get "title" }}
 {{ $width := .Get "width" | default "w_auto" }}
 {{ $style := .Get "style" | default "max-width:80%" }}
-<img alt="{{ $alt }}" title="{{ $alt }}" data-src="https://res.cloudinary.com/{{ $.Site.Params.cloudinary_cloud_name }}/{{ $width }},c_scale,f_auto,q_auto,dpr_auto{{ $image}}" class="cld-responsive" style="{{ $style }}">
+<img alt="{{ $alt }}" title="{{ $alt }}" data-src="https://res.cloudinary.com/{{ $.Site.Params.cloudinary_cloud_name }}/{{ $width }},c_scale,f_auto,q_auto,dpr_auto{{ $image}}" class="cld-responsive" style="padding-bottom: 1rem; {{ $style }}">

--- a/layouts/shortcodes/dynamic-img.html
+++ b/layouts/shortcodes/dynamic-img.html
@@ -1,0 +1,12 @@
+<!--
+    Use as follows:
+    {{< dynamic-img src="/my/image/on/cloudinary.webp" title="A title for the image" >}}
+
+    Optionally, you can customize the width or other general styles for the image:
+    {{< dynamic-img src="/my/image/on/cloudinary.webp" title="A title for the image" width="w_auto" style="width:90%" >}}
+-->
+{{ $image := .Get "src" }}
+{{ $alt := .Get "title" }}
+{{ $width := .Get "width" | default "w_auto" }}
+{{ $style := .Get "style" | default "width:90%" }}
+<img alt="{{ $alt }}" title="{{ $alt }}" data-src="https://res.cloudinary.com/{{ $.Site.Params.cloudinary_cloud_name }}/{{ $width }},c_scale,f_auto,q_auto,dpr_auto{{ $image}}" class="cld-responsive" style="{{ $style }}">

--- a/layouts/shortcodes/dynamic-img.html
+++ b/layouts/shortcodes/dynamic-img.html
@@ -1,12 +1,5 @@
-<!--
-    Use as follows:
-    {{< dynamic-img src="/my/image/on/cloudinary.webp" title="A title for the image" >}}
-
-    Optionally, you can customize the width or other general styles for the image:
-    {{< dynamic-img src="/my/image/on/cloudinary.webp" title="A title for the image" width="w_auto" style="max-width:90%" >}}
--->
 {{ $image := .Get "src" }}
 {{ $alt := .Get "title" }}
 {{ $width := .Get "width" | default "w_auto" }}
 {{ $style := .Get "style" | default "max-width:80%" }}
-<img alt="{{ $alt }}" title="{{ $alt }}" data-src="https://res.cloudinary.com/{{ $.Site.Params.cloudinary_cloud_name }}/{{ $width }},c_scale,f_auto,q_auto,dpr_auto{{ $image}}" class="cld-responsive" style="padding-bottom: 16px; {{ $style }}">
+<img alt="{{ $alt }}" title="{{ $alt }}" data-src="https://res.cloudinary.com/{{ $.Site.Params.cloudinary_cloud_name }}/{{ $width }},c_scale,f_auto,q_auto,dpr_auto{{ $image}}" class="cld-responsive" style="padding-bottom: 16px; display: block; margin: auto; {{ $style }}">

--- a/layouts/shortcodes/dynamic-img.html
+++ b/layouts/shortcodes/dynamic-img.html
@@ -8,5 +8,5 @@
 {{ $image := .Get "src" }}
 {{ $alt := .Get "title" }}
 {{ $width := .Get "width" | default "w_auto" }}
-{{ $style := .Get "style" | default "max-width:90%" }}
+{{ $style := .Get "style" | default "max-width:80%" }}
 <img alt="{{ $alt }}" title="{{ $alt }}" data-src="https://res.cloudinary.com/{{ $.Site.Params.cloudinary_cloud_name }}/{{ $width }},c_scale,f_auto,q_auto,dpr_auto{{ $image}}" class="cld-responsive" style="{{ $style }}">


### PR DESCRIPTION
I was trying to adapt this to this theme and didn't see another option already available, so I thought you might like this PR. Let me know if this isn't the type of change you want to include in the theme.

This optionally provides a capability for responsive images via Cloudinary. It requires images to be hosted in Cloudinary (I have a free account for my blog). It does not add any weight if someone does not wish to use the feature. If they would like to use this, uncommenting `cloudinary_cloud_name` will load in the necessary javascript.

I am using it like this on my markdown articles:
<img width="1003" alt="image" src="https://user-images.githubusercontent.com/6969296/205404963-418162a3-5433-4e24-85c7-b5402217e99d.png">

Notably, the `src` path is the remote path in Cloudinary where my image is located, not a local path. This cloudinary configuration will also auto-select the best image type for the user's browser - e.g. AVIF or webp if supported, else png, jpg, etc. So a file extension is excluded from the path in my example.

The new `meta` tag addition to `head.html` is to gather mobile device dimensions so images can be properly sized in those cases.