### PR TITLE
add primary-font to experience

### DIFF
--- a/layouts/partials/sections/experience.html
+++ b/layouts/partials/sections/experience.html
@@ -5,7 +5,7 @@
         <div class="row justify-content-center">
             <div class="col-sm-12 col-md-8 col-lg-8 py-5">
                 <div class="experience-container px-3 pt-2">
-                    <ul class="nav nav-pills mb-3 bg-transparent" id="pills-tab" role="tablist">
+                    <ul class="nav nav-pills mb-3 bg-transparent primary-font" id="pills-tab" role="tablist">
                         {{ range $index, $element := .Site.Params.experience.items }}
                         {{ if (eq $index 0) }}
                         <li class="nav-item px-1 bg-transparent" role="presentation">


### PR DESCRIPTION
**overview**
keeping font consistent with the rest of the experience section. it was defaulting to Lora (the default body font) but we are using Alata (the primary font) for the rest of the "experience" section. 

**questions**
ideally, we'd want to have a strict style guide for the website where it's explicit what "primary" means (is it just meant for headers? for body? just for the hero? etc) and styles are used consistently throughout the site - or, just use all the same font everywhere, which also is a good alternative. current setup is a bit confusing (`primary-font` is used in the header, post titles, hero, menu, and experience body)

**current state of example experience section**
<img width="941" alt="Screen Shot 2023-01-31 at 11 41 50 PM" src="https://user-images.githubusercontent.com/15808601/215981039-16d4b978-c848-4548-b027-efdbc92ef498.png">

**job section font before:**
<img width="91" alt="Screen Shot 2023-01-31 at 11 34 29 PM" src="https://user-images.githubusercontent.com/15808601/215979731-ec284221-296a-42b6-856a-d8868d9e0a76.png">

**job section font after:**
<img width="89" alt="Screen Shot 2023-01-31 at 11 34 20 PM" src="https://user-images.githubusercontent.com/15808601/215979751-7058248e-d08b-45e8-86fe-4cb83cbf8fc9.png">
