### PR TITLE
Do not put Google Analytics code when running in hugo server

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -24,7 +24,9 @@
 <link rel="stylesheet" href="{{ .Site.Params.staticPath }}/css/font.css" media="all">
 
 <!-- Internal templates -->
-{{ template "_internal/google_analytics.html" . }}
+{{ if not .Site.IsServer }}
+    {{ template "_internal/google_analytics.html" . }}
+{{ end }}
 {{ template "_internal/opengraph.html" . }}
 {{ template "_internal/twitter_cards.html" . }}
 


### PR DESCRIPTION
Would be great to avoid running Google Analytics when creating content locally with `hugo`. Proposing this based on the discussion: here https://github.com/gohugoio/hugo/issues/7422#issuecomment-648977676 and here https://discourse.gohugo.io/t/how-to-exclude-google-analytics-when-running-under-hugo-local-server/6092/34

Excerpt from Hugo docs: https://gohugo.io/variables/site/
> `.Site.IsServer` a boolean to indicate if the site is being served with Hugo’s built-in server. 

