### PR TITLE
fix: provide clearer placeholder for search bar

### DIFF
--- a/layouts/partials/sections/header.html
+++ b/layouts/partials/sections/header.html
@@ -36,7 +36,7 @@
 
             {{ if not (.Site.Params.navbar.disableSearch | default false) }}
                 <div>
-                    <input id="search" autocomplete="off" class="form-control mr-sm-2 d-none d-md-block" placeholder="Ctrl + k"
+                    <input id="search" autocomplete="off" class="form-control mr-sm-2 d-none d-md-block" placeholder="Search"
                         aria-label="Search" oninput="searchOnChange(event)">
                 </div>
             {{ end }}


### PR DESCRIPTION
The placeholder on the search bar should clearly indicate its purpose - "ctrl+k" as a placeholder is confusing to me, at least!