### PR TITLE
Only creating the div if showing recent posts

### DIFF
--- a/layouts/partials/sections/footer/recentBlogPosts.html
+++ b/layouts/partials/sections/footer/recentBlogPosts.html
@@ -1,5 +1,6 @@
+{{ $currentNumOfrecentPosts := len (where .Site.RegularPages "Type" "posts") }} 
+{{ if and (gt $currentNumOfrecentPosts 0) (.Site.Params.footer.recentPosts.enable | default false) }} 
 <div class="container py-3" id="recent-posts">
-    {{ if .Site.Params.footer.recentPosts.enable | default false }}
     {{ $recentPostsPath := .Site.Params.footer.recentPosts.path | default "blogs" }}
     {{ $recentPostsCount := .Site.Params.footer.recentPosts.count | default 3 }}
     {{ $recentPosts := where .Site.RegularPages "Section" $recentPostsPath | first $recentPostsCount }}
@@ -33,5 +34,5 @@
         </div>
         {{ end }}
     </div>
-    {{ end }}
 </div>
+{{ end }}


### PR DESCRIPTION
Hi,

I thought that it's better to avoid adding the recent-posts div to the DOM if that section is not enabled. Also, I've modified the logic so that if there are no posts, it will be considered disabled instead of showing the title with no further content.

Hope this is Ok.