### PR TITLE
Centered Single Blog Feature Images

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -32,7 +32,7 @@
           </div>
           {{ if .Params.image }}
           <div class="featured-image">
-            <img class="img-fluid" src="{{ .Params.image }}" alt="{{ .Title }}">
+            <img class="img-fluid mx-auto d-block" src="{{ .Params.image }}" alt="{{ .Title }}">
           </div>
           {{ end }}
           <article class="page-content  p-2">


### PR DESCRIPTION
I have tested it i think this works. 

I couldn't find a way to center the images in the content of blog posts, it uses `{{ .Content | emojify }}` and i don't know how this is interpreting images. 😅😅

Screenshots:

#### BEFORE 
![image](https://github.com/gurusabarish/hugo-profile/assets/81550376/c3664bd6-61c8-4577-bba6-24314dd4d85e)

---

#### AFTER
![image](https://github.com/gurusabarish/hugo-profile/assets/81550376/7b53b64d-987b-4d6a-8259-c13219d0a5ea)
