### PR TITLE
Allow mathjax to be set globally

### DIFF
--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -67,6 +67,9 @@ params:
   # This requires your images to be uploaded + hosted on Cloudinary
   # Uncomment and change YOUR_CLOUD_NAME to the Cloud Name in your Cloudinary console
   # cloudinary_cloud_name: "YOUR_CLOUD_NAME"
+  
+  # Whether to add mathjax support on all pages. Alternatively, you can opt-in per page by adding `mathjax: true` in the frontmatter.
+  mathjax: false
 
   # Whether the fade animations on the home page will be enabled
   animate: true

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -54,7 +54,7 @@
 {{ end }}
 
 
-{{ if (.Params.mathjax | default false) }}
+{{ if or (.Params.mathjax | default false) (.Site.Params.mathjax) }}
 
 {{ "<!-- MathJax -->" | safeHTML }}
 <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.2.2/es5/tex-mml-chtml.min.js" integrity="sha384-M5jmNxKC9EVnuqeMwRHvFuYUE8Hhp0TgBruj/GZRkYtiMrCRgH7yvv5KY+Owi7TW" crossorigin="anonymous"></script>


### PR DESCRIPTION
Hi @gurusabarish, thanks for the theme. I've opened issue #136, and since I don't think it's a major change, I also opened this PR. Please, let me know otherwise.

This allows `mathjax: true` to be set in the `config.yaml` file.
This will simply add the existing Mathjax script to all pages, as was originally mentioned in #83.
The example `config.yaml` is also updated with this parameter and a short comment.

Closes #136 
