### PR TITLE
Update README.md hugo new site syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Technology used: Bootstrap, fontawesome
 [For more details](https://github.com/gurusabarish/hugo-profile/wiki)
 ## Hugo theme
 
-- Install Hugo and create a site using `hugo new site my-site -f=yaml`
+- Install Hugo and create a site using `hugo new site my-site --format="yaml"`
 - Clone this repo inside your themes folder
 ```
 cd themes


### PR DESCRIPTION
updated line 43 for hugo new site with --format flag instead of -f. Put YAML in double quotations to align with the hugo-new-site man page

### error when using -f flag
Error: command error: invalid argument "yaml" for "-f, --force" flag: strconv.ParseBool: parsing "yaml": invalid syntax

### man page information
--format string   preferred file format (toml, yaml or json) (default "toml")