### PR TITLE
show company url only if available

### DIFF
--- a/layouts/partials/sections/experience.html
+++ b/layouts/partials/sections/experience.html
@@ -49,8 +49,10 @@
                         >
                             <div>
                                 <span class="h4">{{ .job }}</span>
+                                {{ if .companyUrl }}
                                 <small>-</small>
-                                <a href="{{ .companyUrl }}" target="_blank">{{ .company }}</a>
+                                    <a href="{{ .companyUrl }}" target="_blank">{{ .company }}</a>
+                                {{ end }}
                                 <div class="pb-1">
                                     <small>{{ .date }}</small>
                                     {{ if .info.enable | default true }}
@@ -88,8 +90,10 @@
                             <div>
                                 <span class="h4">{{ .job }}</span>
                                 <small>-</small>
-                                <a href="{{ .companyUrl }}" target="_blank">{{ .company }}</a>
-                                
+                                {{ if .companyUrl }}
+                                <small>-</small>
+                                    <a href="{{ .companyUrl }}" target="_blank">{{ .company }}</a>
+                                {{ end }}
                                 <div class="pb-1">
                                     <small>{{ .date }}</small>
                                     {{ if .info.enable | default true }}


### PR DESCRIPTION
I use the experience boxes for showcasing my own projects as a freelancer. So there are customers that don't have a company url (or it is just not important). So I thought it would be great to disable the Link if the link is not present.