### PR TITLE
Add Open Graph and Twitter Card meta tags to improve social media sharing

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -4,6 +4,23 @@
 <head>
   {{- partial "head.html" . -}}
   {{- block "head" . }} {{- end }}
+  <!-- Open Graph and Twitter Card Meta Tags -->
+  {{ with .Params.image }}
+  <meta property="og:image" content="{{ . | absURL }}">
+  {{ end }}
+  <meta property="og:title" content="{{ .Title }}">
+  <meta property="og:description" content="{{ .Description }}">
+  <meta property="og:url" content="{{ .Permalink }}">
+  <meta property="og:type" content="article">
+  <meta property="og:site_name" content="{{ .Site.Title }}">
+
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="{{ .Title }}">
+  <meta name="twitter:description" content="{{ .Description }}">
+  {{ with .Params.image }}
+  <meta name="twitter:image" content="{{ . | absURL }}">
+  {{ end }}
+  <!-- End of Open Graph and Twitter Card Meta Tags -->
   <title>
     {{- block "title" . }} {{- end }}
   </title>


### PR DESCRIPTION
This commit adds Open Graph and Twitter Card meta tags to the `<head>` section of the `baseof.html` file. These tags enhance the display of website content when shared on social media platforms like Facebook and Twitter.

Changes made:
- Added `og:image`, `og:title`, `og:description`, `og:url`, `og:type`, and `og:site_name` for Open Graph.
- Added `twitter:card`, `twitter:title`, `twitter:description`, and optional `twitter:image` for Twitter Card.

The values for these tags are dynamically populated based on the content of the page. Additionally, `fb:app_id` is recommended but can be added separately as needed.

This enhancement aims to provide a better visual representation when sharing pages from the website on various social networks.