### PR TITLE
Don't open hero social link if href is local

### DIFF
--- a/layouts/partials/sections/hero/social.html
+++ b/layouts/partials/sections/hero/social.html
@@ -1,7 +1,10 @@
 <span>
     {{ range .Site.Params.hero.socialLinks.fontAwesomeIcons }}
     <span class="px-1">
-        <a href="{{ .url }}" target="_blank" class="btn social-icon">
+        <a href="{{ .url }}"
+            {{ if not (hasPrefix .url "#") }} target="_blank" {{ end }}
+            class="btn social-icon"
+        >
             <i class="{{ .icon }}"></i>
         </a>
     </span>
@@ -9,7 +12,10 @@
 
     {{ range .Site.Params.hero.socialLinks.customIcons }}
     <span class="px-1">
-        <a href="{{ .url }}" target="_blank" class="btn social-icon">
+        <a href="{{ .url }}"
+            {{ if not (hasPrefix .url "#") }} target="_blank" {{ end }}
+            class="btn social-icon"
+        >
             <img src="{{ .icon }}">
         </a>
     </span>


### PR DESCRIPTION
In case link for a social icon in the hero image is set to local link (e.g., "#contact"), don't open it in a new tab. It's useful if you don't want to publish a link to your e-mail in clear text, and rather redirect user to the contact form.