### PR TITLE
Fix logo display if no logo/favicon are set

### DIFF
--- a/layouts/partials/sections/footer/copyright.html
+++ b/layouts/partials/sections/footer/copyright.html
@@ -1,12 +1,14 @@
 <div class="container py-4">
     <div class="row justify-content-center">
         <div class="col-md-4 text-center">
-            <div class="pb-2">
-                <a href="{{ .Site.BaseURL }}" title="{{ .Site.Title }}">
-                    <img alt="Footer logo" src="{{ .Site.Params.navbar.brandLogo | default .Site.Params.favicon }}"
-                        height="40px" width="40px">
-                </a>
-            </div>
+            {{ if or .Site.Params.navbar.brandLogo .Site.Params.favicon }}
+                <div class="pb-2">
+                    <a href="{{ .Site.BaseURL }}" title="{{ .Site.Title }}">
+                        <img alt="Footer logo" src="{{ .Site.Params.navbar.brandLogo | default .Site.Params.favicon }}"
+                            height="40px" width="40px">
+                    </a>
+                </div>
+            {{ end }}
             &copy; {{ now.Format "2006"}} {{ .Site.Params.copyright }} {{ .Site.Params.terms.copyright | default "All Rights Reserved" }}
             <div class="text-secondary">
                 Made with

--- a/layouts/partials/sections/header.html
+++ b/layouts/partials/sections/header.html
@@ -40,7 +40,7 @@
         if(resetHeaderStyle) {
             profileHeaderElem.classList.remove("showHeaderOnTop");
         }
-        prevScrollPos = currentScrollPos;        
+        prevScrollPos = currentScrollPos;
     });
 </script>
 {{ end }}
@@ -51,7 +51,7 @@
         <div class="container-fluid mx-xs-2 mx-sm-5 mx-md-5 mx-lg-5">
             <!-- navbar brand -->
             <a class="navbar-brand primary-font text-wrap" href="{{ .Site.BaseURL | relURL }}">
-                {{ if and (or (.Site.Params.favicon) (.Site.Params.navbar.brandLogo)) .Site.Params.navbar.showBrandLogo | default true }}
+                {{ if and (or (.Site.Params.favicon) (.Site.Params.navbar.brandLogo)) (.Site.Params.navbar.showBrandLogo | default true) }}
                 <img src="{{ .Site.Params.navbar.brandLogo | default .Site.Params.favicon }}" width="30" height="30"
                     class="d-inline-block align-top">
                 {{ .Site.Params.navbar.brandName | default .Site.Params.title }}


### PR DESCRIPTION
This PR fixes two bugs:
- Previously, an empty image was shown if neither `navbar.brandLogo` or `favicon` were set.
- Even if `navbar.showBrandLogo` was set to false, the (empty) navbar logo would be shown.