### PR TITLE
Hide vertical rule in single if no author is set

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -19,8 +19,10 @@
           <div class="title mb-5">
             <h1 class="text-center mb-4">{{ .Title }}</h1>
             <div class="text-center">
-              {{ .Params.author }} 
-              <small>|</small>
+              {{ if .Params.author }}
+                {{ .Params.author }}
+                <small>|</small>
+              {{ end }}
               {{ .Date.Format (.Site.Params.datesFormat.article | default "Jan 2, 2006") }}
 
               {{ if or (.Site.Params.singlePages.readTime.enable | default true) (.Params.enableReadingTime) }}


### PR DESCRIPTION
Before, even if no author was set, vertical rule was shown before the date on the top of a single page.