### PR TITLE
Move custom style declaration to baseof

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -4,6 +4,12 @@
 <head>
   {{- partial "head.html" . -}}
   {{- block "head" . }} {{- end }}
+
+  <!-- Custom Styles -->
+  {{ if .Site.Params.customCSS }}
+    <link rel="stylesheet" href="{{ .Site.Params.staticPath }}/style.css">
+  {{ end }}
+
   <title>
     {{- block "title" . }} {{- end }}
   </title>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -40,11 +40,6 @@
 <!-- theme -->
 <link rel="stylesheet" href="{{ .Site.Params.staticPath }}/css/theme.css" media="all">
 
-<!-- Custom Styles -->
-{{ if .Site.Params.customCSS }}
-<link rel="stylesheet" href="{{ .Site.Params.staticPath }}/style.css">
-{{ end }}
-
 <style>
     :root {
         --text-color: {{ .Site.Params.color.textColor | default "#343a40" }};
@@ -78,11 +73,11 @@
         width: 8px;
         background-color: var(--background-color);
     }
-    
+
     ::-webkit-scrollbar-track {
         border-radius: 1rem;
     }
-    
+
     ::-webkit-scrollbar-thumb {
         border-radius: 1rem;
         background: #b0b0b0;


### PR DESCRIPTION
This ensures that custom style takes precedent over theme styles. Useful when overriding theme styles for, e.g., single page.