### PR TITLE
Add support for customizable link text color

### DIFF
--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -89,7 +89,7 @@ params:
   # color:
   #   textColor: "#343a40"
   #   secondaryTextColor: "#6c757d"
-  #   textLinkColor: "#0d6efd"
+  #   textLinkColor: "#007bff"
   #   backgroundColor: "#eaedf0"
   #   secondaryBackgroundColor: "#64ffda1a"
   #   primaryColor: "#007bff"
@@ -98,7 +98,7 @@ params:
   #   darkmode:
   #     textColor: "#e4e6eb"
   #     secondaryTextColor: "#b0b3b8"
-  #     textLinkColor: "#0d6efd"
+  #     textLinkColor: "#ffffff"
   #     backgroundColor: "#18191a"
   #     secondaryBackgroundColor: "#212529"
   #     primaryColor: "#ffffff"

--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -89,6 +89,7 @@ params:
   # color:
   #   textColor: "#343a40"
   #   secondaryTextColor: "#6c757d"
+  #   textLinkColor: "#0d6efd"
   #   backgroundColor: "#eaedf0"
   #   secondaryBackgroundColor: "#64ffda1a"
   #   primaryColor: "#007bff"
@@ -97,6 +98,7 @@ params:
   #   darkmode:
   #     textColor: "#e4e6eb"
   #     secondaryTextColor: "#b0b3b8"
+  #     textLinkColor: "#0d6efd"
   #     backgroundColor: "#18191a"
   #     secondaryBackgroundColor: "#212529"
   #     primaryColor: "#ffffff"

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -44,7 +44,7 @@
     :root {
         --text-color: {{ .Site.Params.color.textColor | default "#343a40" }};
         --text-secondary-color: {{ .Site.Params.color.secondaryTextColor | default "#6c757d" }};
-        --text-link-color: {{ .Site.Params.color.textLinkColor | default "#0d6efd" }};
+        --text-link-color: {{ .Site.Params.color.textLinkColor | default (.Site.Params.color.primaryColor | default "#007bff") }};
         --background-color: {{ .Site.Params.color.backgroundColor | default "#eaedf0" }};
         --secondary-background-color: {{ .Site.Params.color.secondaryBackgroundColor | default "#64ffda1a" }};
         --primary-color: {{ .Site.Params.color.primaryColor | default "#007bff" }};
@@ -53,7 +53,7 @@
         /* dark mode colors */
         --text-color-dark: {{ .Site.Params.color.darkmode.textColor | default "#e4e6eb" }};
         --text-secondary-color-dark: {{ .Site.Params.color.darkmode.secondaryTextColor | default "#b0b3b8" }};
-        --text-link-color-dark: {{ .Site.Params.color.textLinkColor | default "#0d6efd" }};
+        --text-link-color-dark: {{ .Site.Params.color.darkmode.textLinkColor | default (.Site.Params.color.darkmode.primaryColor | default "#ffffff") }};
         --background-color-dark: {{ .Site.Params.color.darkmode.backgroundColor | default "#18191a" }};
         --secondary-background-color-dark: {{ .Site.Params.color.darkmode.secondaryBackgroundColor | default "#212529" }};
         --primary-color-dark: {{ .Site.Params.color.darkmode.primaryColor | default "#ffffff" }};

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -44,6 +44,7 @@
     :root {
         --text-color: {{ .Site.Params.color.textColor | default "#343a40" }};
         --text-secondary-color: {{ .Site.Params.color.secondaryTextColor | default "#6c757d" }};
+        --text-link-color: {{ .Site.Params.color.textLinkColor | default "#0d6efd" }};
         --background-color: {{ .Site.Params.color.backgroundColor | default "#eaedf0" }};
         --secondary-background-color: {{ .Site.Params.color.secondaryBackgroundColor | default "#64ffda1a" }};
         --primary-color: {{ .Site.Params.color.primaryColor | default "#007bff" }};
@@ -52,6 +53,7 @@
         /* dark mode colors */
         --text-color-dark: {{ .Site.Params.color.darkmode.textColor | default "#e4e6eb" }};
         --text-secondary-color-dark: {{ .Site.Params.color.darkmode.secondaryTextColor | default "#b0b3b8" }};
+        --text-link-color-dark: {{ .Site.Params.color.textLinkColor | default "#0d6efd" }};
         --background-color-dark: {{ .Site.Params.color.darkmode.backgroundColor | default "#18191a" }};
         --secondary-background-color-dark: {{ .Site.Params.color.darkmode.secondaryBackgroundColor | default "#212529" }};
         --primary-color-dark: {{ .Site.Params.color.darkmode.primaryColor | default "#ffffff" }};

--- a/static/css/about.css
+++ b/static/css/about.css
@@ -27,7 +27,7 @@
 #single .page-content a {
     display: inline-block;
     text-decoration: none;
-    color: var(--primary-color) !important;
+    color: var(--text-link-color) !important;
 }
 
 #single .page-content a::after {

--- a/static/css/footer.css
+++ b/static/css/footer.css
@@ -4,7 +4,7 @@ footer a h5 {
 
 footer a {
   text-decoration: none;
-  color: var(--text-secondary-color) !important;
+  color: var(--text-link-color) !important;
 }
 
 footer a:hover {
@@ -35,7 +35,7 @@ footer .card-footer {
 }
 
 footer .card-footer a {
-    color: var(--text-secondary-color) !important;
+    color: var(--text-link-color) !important;
     border-color: var(--primary-color) !important;
     transition: none;
     background-color: var(--background-color) !important;

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -175,7 +175,7 @@ header .navbar.animate {
 #hero .hero-content > a {
     display: inline-block;
     text-decoration: none;
-    color: var(--primary-color) !important;
+    color: var(--text-link-color) !important;
 }
 
 #hero .hero-content > a::after {
@@ -243,7 +243,7 @@ header .navbar.animate {
 #about a {
     display: inline-block;
     text-decoration: none;
-    color: var(--primary-color) !important;
+    color: var(--text-link-color) !important;
 }
 
 #about a::after {
@@ -322,7 +322,7 @@ header .navbar.animate {
     opacity: 0.9;
     display: inline-block;
     text-decoration: none;
-    color: var(--primary-color) !important;
+    color: var(--text-link-color) !important;
 }
 
 #experience a::after {
@@ -432,7 +432,7 @@ header .navbar.animate {
 }
 
 #education .card .card-body .education-content a {
-    color: var(--primary-color) !important;
+    color: var(--text-link-color) !important;
     text-decoration: none;
     opacity: 0.9;
 }
@@ -440,7 +440,7 @@ header .navbar.animate {
 #education .card .card-body > a h6 {
     display: inline-block;
     text-decoration: none;
-    color: var(--primary-color) !important;
+    color: var(--text-link-color) !important;
 }
 
 #education .card .card-body > a h6::after {

--- a/static/css/projects.css
+++ b/static/css/projects.css
@@ -6,7 +6,7 @@
 
 #projects a {
     text-decoration: none;
-    color: var(--text-color) !important;
+    color: var(--text-link-color) !important;
 }
 
 #projects .badge {

--- a/static/css/single.css
+++ b/static/css/single.css
@@ -33,7 +33,7 @@
 #single .page-content a {
     display: inline-block;
     text-decoration: none;
-    color: var(--primary-color) !important;
+    color: var(--text-link-color) !important;
 }
 
 #single .page-content a::after {
@@ -52,7 +52,7 @@
 }
 
 #single .page-content h1, #single .page-content h2, #single .page-content h3, #single .page-content h4, #single .page-content h5, #single .page-content h6 {
-    color: var(--primary-color) !important;
+    color: var(--text-link-color) !important;
     margin-bottom: 0.7em;
     opacity: 0.9;
 }
@@ -188,7 +188,7 @@
     border-radius: 10px;
     background-color: var(--background-color);
     text-decoration: none;
-    color: var(--text-color);
+    color: var(--text-link-color) !important;
 }
 
 #single aside.tags ul.tags-ul li {
@@ -223,7 +223,7 @@
 #single aside.toc .toc-content ol li a, #single aside.toc .toc-content ul li a {
     font-size: 16px;
     text-decoration: none;
-    color: var(--text-color);
+    color: var(--text-link-color) !important;
     opacity: 0.9;
 }
 
@@ -261,7 +261,7 @@
 #single aside.social .social-content ul li a {
     border: 1px solid var(--primary-color);
     padding: .7rem;
-    color: var(--text-color);
+    color: var(--text-link-color) !important;
     border-radius: 10px;
     overflow: hidden;
 }
@@ -273,7 +273,7 @@
 
 #single aside.social .social-content ul li:hover a {
     opacity: .8;
-    color: var(--primary-color);
+    color: var(--text-link-color) !important;
 }
 
 /* Top scroll */

--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -10,6 +10,7 @@
     --secondary-background-color: var(--secondary-background-color-dark) !important;
     --text-color: var(--text-color-dark) !important;
     --text-secondary-color: var(--text-secondary-color-dark) !important;
+    --text-link-color: var(--text-link-color-dark) !important;
     --primary-color: var(--primary-color-dark);
     --secondary-color: var(--secondary-color-dark);
 }


### PR DESCRIPTION
Currently, the font color for links are the same as any normal text when using darkmode:

![image](https://github.com/gurusabarish/hugo-profile/assets/75533906/c736b3ce-6535-4246-ac73-6ea9511db1fd)

This PR would allow the user to set a custom font color for links, and the default has been changed to this:

![image](https://github.com/gurusabarish/hugo-profile/assets/75533906/bf6c4a70-9f2b-40c6-a240-d324430c96e5)

This would allow users to easily modify the link font colors, as I personally wanted to change it to the blue above but couldn't via the config-file