### PR TITLE
add dark class to html tag

### DIFF
--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -2,6 +2,7 @@
 <script>
     if (document.body.className.includes("dark")) {
         document.body.classList.remove('dark');
+        document.documentElement.classList.remove('dark');
         localStorage.setItem("pref-theme", 'light');
     }
 </script>
@@ -10,6 +11,7 @@
 {{- /* theme is dark */}}
 <script>
     if (document.body.className.includes("light")) {
+        document.documentElement.classList.add('dark');
         document.body.classList.add('dark');
         localStorage.setItem("pref-theme", 'dark');
     }
@@ -19,10 +21,13 @@
 {{- /* theme is auto */}}
 <script>
     if (localStorage.getItem("pref-theme") === "dark") {
+        document.documentElement.classList.add('dark');
         document.body.classList.add('dark');
     } else if (localStorage.getItem("pref-theme") === "light") {
         document.body.classList.remove('dark')
+        document.documentElement.classList.remove('dark');
     } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        document.documentElement.classList.add('dark');
         document.body.classList.add('dark');
     }
 
@@ -34,9 +39,11 @@
     document.getElementById("theme-toggle").addEventListener("click", () => {
         if (document.body.className.includes("dark")) {
             document.body.classList.remove('dark');
+            document.documentElement.classList.remove('dark');
             localStorage.setItem("pref-theme", 'light');
         } else {
             document.body.classList.add('dark');
+            document.documentElement.classList.add('dark');
             localStorage.setItem("pref-theme", 'dark');
         }
     })

--- a/layouts/partials/sections/header.html
+++ b/layouts/partials/sections/header.html
@@ -5,13 +5,16 @@
 
     switch (localStorageValue) {
         case "dark":
+            document.documentElement.classList.add('dark');
             document.body.classList.add('dark');
             break;
         case "light":
             document.body.classList.remove('dark');
+            document.documentElement.classList.remove('dark');
             break;
         default:
             if (mediaQuery) {
+                document.documentElement.classList.add('dark');
                 document.body.classList.add('dark');
             }
             break;


### PR DESCRIPTION
Adding class dark to html tag so that background color will be black in dark theme when scroll beyond top using trackpad in.
 
 Instead of looking like this
 
![2024-08-25-130500](https://github.com/user-attachments/assets/9150e80c-5cd5-4ffc-af9b-2c6429e9f416)

It will look like this
![2024-08-25-115101](https://github.com/user-attachments/assets/cad298db-6060-4579-aac8-6b2c93cc768e)

note: Currently not all browsers have this feature ( not available in chromium,brave and also in firefox but recently added in firefox-developer-edition so it could be added in normal firefox soon )
