### PR TITLE
Add "Featured Video" Support for Blog Posts

### DIFF
--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -5,6 +5,7 @@ draft: true
 author:
 tags:
 image:
+video:
 description:
 toc:
 ---

--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -372,6 +372,7 @@ params:
       title: Recent Posts
       enable: true
       disableFeaturedImage: false
+      disableFeaturedVideo: false
     socialNetworks:
       github: https://github.com
       linkedin: https://linkedin.com
@@ -382,7 +383,7 @@ params:
   # List pages like blogs and posts
   listPages:
     disableFeaturedImage: false
-
+    disableFeaturedVideo: false
   # Single pages like blog and post
   singlePages:
     socialShare: true

--- a/exampleSite/content/blogs/video_support.md
+++ b/exampleSite/content/blogs/video_support.md
@@ -1,0 +1,107 @@
+---
+title: "Video Support to Blog Posts"
+date: 2021-09-06T22:41:10+05:30
+draft: false
+author: "Robert Viquez"
+tags: 
+    - Hugo
+    - Video
+description: "Brief overview of how video support was added to blog posts."
+# image:
+video: "https://res.cloudinary.com/dqyllgamr/video/upload/v1725611771/ExampleVideo_uifgil.mp4" 
+toc: true
+---
+
+---
+
+## Overview
+
+This guide briefly outlines how to add video support to blog posts in Hugo. The implementation involves updating configuration files and layout templates to handle video content.
+
+## Configuration Updates
+
+### `config.yaml`
+
+Updated to enable video support:
+
+```yaml
+disableFeaturedImage: false
+disableFeaturedVideo: false
+```
+
+## Layout Modifications
+
+### List Page (`layouts/_default/list.html`)
+
+Added video support:
+
+```html
+{{ if .Params.video }}
+<div class="video-container">
+    <video width="640" height="360" autoplay loop>
+        <source src="{{ .Params.video }}" type="video/mp4">
+        Your browser does not support video.
+    </video>
+</div>
+{{ end }}
+```
+
+### Single Page (`layouts/_default/single.html`)
+
+Included video support:
+
+```html
+{{ if .Params.video }}
+<div class="video-container">
+    <video width="640" height="360" autoplay loop>
+        <source src="{{ .Params.video }}" type="video/mp4">
+        Your browser does not support video.
+    </video>
+</div>
+{{ end }}
+```
+
+## CSS Adjustments
+
+### List Page (`static/css/list.css`)
+
+Styled video containers:
+
+```css
+.video-container {
+    position: relative;
+    padding-top: 56.25%; 
+    width: 100%; 
+    max-width: 640px; 
+    margin: 0 auto; 
+}
+
+.video-container video {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%; 
+    height: 100%; 
+    border-radius: 8px; 
+}
+```
+
+### Single Page (`static/css/single.css`)
+
+Centered video on single pages:
+
+```css
+#single .video-container {
+    display: flex; 
+    justify-content: center; 
+    align-items: center;
+}
+
+#single .video-container video {
+    border-radius: 16px; 
+}
+```
+
+## Conclusion
+
+These changes add video support to blog posts, enhancing both list and single post displays. 

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -18,7 +18,20 @@
                     {{ if and (not (.Site.Params.listPages.disableFeaturedImage | default false)) (.Params.image) }}
                     <div class="card-header">
                         <a href="{{ .RelPermalink }}">
+                            
                             <img src="{{ .Params.image }}" class="card-img-top" alt="{{ .Title }}">
+                        </a>
+                    </div>
+                    {{ end }}
+                    {{ if and (not (.Site.Params.listPages.disableFeaturedVideo | default true)) (.Params.video) }}
+                    <div class="card-header">
+                        <a href="{{ .RelPermalink }}">
+                            <div class="video-container" style="text-align: center;">
+                                <video width="640" height="360" autoplay loop>
+                                <source src="{{ .Params.video }}" type="video/mp4" alt="{{ .Title }}">
+                                Your browser does not support video.
+                                </video>
+                            </div>
                         </a>
                     </div>
                     {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,15 +1,12 @@
 {{ define "head" }}
 <meta name="description" content="{{ .Params.description }}">
 <link rel="stylesheet" href="{{.Site.Params.staticPath}}/css/single.css">
-
 <!-- fontawesome -->
 <script defer src="{{.Site.Params.staticPath}}/fontawesome-6/all-6.4.2.js"></script>
 {{ end }}
-
 {{ define "title" }}
 {{.Title }} | {{ .Site.Title }}
 {{ end }}
-
 {{ define "main" }}
 <section id="single">
   <div class="container">
@@ -24,7 +21,6 @@
                 <small>|</small>
               {{ end }}
               {{ .Date.Format (.Site.Params.datesFormat.article | default "Jan 2, 2006") }}
-
               {{ if or (.Site.Params.singlePages.readTime.enable | default true) (.Params.enableReadingTime) }}
               <span id="readingTime">
                 {{ .Site.Params.singlePages.readTime.content | default "min read" }}
@@ -35,6 +31,14 @@
           {{ if .Params.image }}
           <div class="featured-image">
             <img class="img-fluid mx-auto d-block" src="{{ .Params.image }}" alt="{{ .Title }}">
+          </div>
+          {{ end }}
+          {{ if .Params.video }}
+          <div class="video-container" style="text-align: center;">
+            <video width="640" height="360" autoplay loop>
+              <source src="{{ .Params.video }}" type="video/mp4" alt="{{ .Title }}">
+              Your browser does not support video.
+            </video>
           </div>
           {{ end }}
           <article class="page-content  p-2">
@@ -54,7 +58,6 @@
               </div>
           </aside>
           {{ end }}
-
           {{ if .Params.tags }}
           <aside class="tags">
             <h5>{{ .Site.Params.terms.tags | default "Tags" }}</h5>
@@ -67,7 +70,6 @@
             </ul>
           </aside>
           {{end}}
-
           {{ if .Params.socialShare | default .Site.Params.singlePages.socialShare | default true }}
           <aside class="social">
             <h5>{{ .Site.Params.terms.social | default "Social" }}</h5>
@@ -110,18 +112,15 @@
     <i class="fas fa-angle-up"></i>
   </button>
 </section>
-
 {{ if or (.Site.Params.singlePages.scrollprogress.enable | default true) (.Params.enableScrollProgress) }}
 <div class="progress">
   <div id="scroll-progress-bar" class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
 </div>
 <Script src="{{.Site.Params.staticPath}}/js/scrollProgressBar.js"></script>
 {{ end }}
-
 <script>
   var topScroll = document.getElementById("topScroll");
   window.onscroll = function() {scrollFunction()};
-
   function scrollFunction() {
     if (document.body.scrollTop > 20 || document.documentElement.scrollTop > 20) {
       topScroll.style.display = "block";
@@ -129,12 +128,10 @@
       topScroll.style.display = "none";
     }
   }
-
   function topFunction() {
     document.body.scrollTop = 0;
     document.documentElement.scrollTop = 0;
   }
-
   // To set height of sticky sidebar dynamically
   let stickySideBarElem = document.getElementById("stickySideBar");
   let stickyNavBar = {{ .Site.Params.navbar.stickyNavBar.enable | default false }};
@@ -146,9 +143,7 @@
     stickySideBarElem.style.top = "50px";
   }
 </script>
-
 {{ if or (.Site.Params.singlePages.readTime.enable | default true) (.Params.enableReadingTime) }}
 <script src="{{.Site.Params.staticPath}}/js/readingTime.js"></script>
 {{end}}
-
 {{ end }}

--- a/layouts/partials/sections/footer/recentBlogPosts.html
+++ b/layouts/partials/sections/footer/recentBlogPosts.html
@@ -18,6 +18,16 @@
                     </a>
                 </div>
                 {{ end }}
+                {{ if and (not (.Site.Params.footer.recentPosts.disableFeaturedVideo | default false)) (.Params.image) }}
+                <div class="card-header">
+                    <div class="video-container" style="text-align: center;">
+                        <video width="640" height="360" autoplay loop>
+                        <source src="{{ .Params.video }}" type="video/mp4" alt="{{ .Title }}">
+                        Your browser does not support video.
+                        </video>
+                    </div>
+                </div>
+                {{ end }}
                 <div class="card-body bg-transparent p-3 shadow-sm">
                     <a href="{{ .RelPermalink }}" class="primary-font card-title">
                         <h5 class="card-title bg-transparent" title="{{ .Title }}">{{ .Title | truncate 25 }}</h5>

--- a/static/css/list.css
+++ b/static/css/list.css
@@ -48,6 +48,7 @@
 }
 
 #list-page .card > .card-header {
+    display: contents;
     padding: 0 !important;
     border: none !important;
     background-color: var(--secondary-color) !important;
@@ -57,6 +58,24 @@
     width: 100%;
     height: 250px !important;
     background-color: transparent !important;
+}
+
+.video-container {
+    position: relative;
+    padding-top: 56.25%; 
+    width: 100%; /* Full width of the parent container */
+    max-width: 640px; 
+    margin: 0 auto; /* Center the container */
+    overflow: auto; /* Hide overflow to maintain aspect ratio */
+}
+
+.video-container video {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%; 
+    height: 100%; 
+    border-radius: 8px; /* Add rounded corners */
 }
 
 /* pagination */

--- a/static/css/single.css
+++ b/static/css/single.css
@@ -13,6 +13,18 @@
     opacity: 0.7;
 }
 
+#single .video-container {
+    justify-content: center; 
+    align-items: center; 
+    display: flex; 
+}
+
+#single .video-container video{
+    align-self: center;
+    border-radius: 16px; 
+    display: block;
+}
+
 #single .featured-image {
     padding: 1rem;
     padding-top: 0;
@@ -94,6 +106,7 @@
     border: 1px solid var(--secondary-color);
     opacity: 0.9;
 }
+
 #single .page-content table > tbody > tr > td {
     padding: 0.5rem !important;
     border: 1px solid var(--secondary-color);
@@ -109,33 +122,33 @@
 /* code */
 
 #single .page-content pre {
-  border-radius: 0.7em !important;
-  margin: 5px;
-  margin-bottom: 2em;
-  padding: 2em;
-  background-color: var(--secondary-color) !important;
-  color: var(--text-secondary-color) !important;
-  max-height: 450px;
+    border-radius: 0.7em !important;
+    margin: 5px;
+    margin-bottom: 2em;
+    padding: 2em;
+    background-color: var(--secondary-color) !important;
+    color: var(--text-secondary-color) !important;
+    max-height: 450px;
 }
 
 #single .page-content pre > code {
-  color: var(--text-secondary-color) !important;
+    color: var(--text-secondary-color) !important;
 }
 
 #single .page-content code {
-  color: var(--primary-color) !important;
+    color: var(--primary-color) !important;
 }
 
 /* kbd and mark */
 
 #single .page-content kbd {
-  color: var(--primary-color) !important;
-  background-color: var(--secondary-color) !important;
+    color: var(--primary-color) !important;
+    background-color: var(--secondary-color) !important;
 }
 
 #single .page-content mark {
-  color: var(--primary-color) !important;
-  background-color: var(--secondary-color) !important;
+    color: var(--primary-color) !important;
+    background-color: var(--secondary-color) !important;
 }
 
 /* list */
@@ -162,7 +175,7 @@
 }
 
 #single .sticky-sidebar {
-  position: sticky;
+    position: sticky;
 }
 
 #single .sticky-sidebar ::-webkit-scrollbar {


### PR DESCRIPTION

This feature adds support for embedding videos in blog posts on the. It introduces the `featuredVideo` parameter in the `config.yaml`, allowing videos to be displayed as featured media on both the blog listing and individual blog post pages.

### Key Changes:
- Updated `config.yaml` to include the `featuredVideo` parameter for managing blog post videos.
- Modified `layouts/_default/list.html` to display videos on the blog list view when available.
- Updated `layouts/_default/single.html` to support video embedding on individual blog post pages.
- Videos will be displayed prominently when the `featuredVideo` parameter is specified in the blog's front matter.

### Tested
- Verified that adding a `featuredVideo` parameter to a blog post successfully embeds the video in both list and single views.
- Ensured that blog posts without a `featuredVideo` parameter continue to display as expected.

 [Demo](https://robertviquez.com/blogs/netlify_deployment_github_submodule/)