### PR TITLE
HUGO deprecated value

### DIFF
--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -12,7 +12,9 @@ outputs:
     - "HTML"
     - "RSS"
 
-Paginate: 3
+pagination:
+  pagerSize: 3
+
 enableRobotsTXT: true
 # disqusShortname: your-disqus-shortname
 # googleAnalytics: G-MEASUREMENT_ID


### PR DESCRIPTION
The old config option seems to be deprecated in Hugo, ¿can you check it and update?

WARN  deprecated: site config key paginate was deprecated in Hugo v0.128.0 and will be removed in a future release. Use pagination.pagerSize instead.

My environment:

[...]$ hugo version
hugo v0.138.0-ad82998d54b3f9f8c2741b67356813b55b3134b9+extended linux/amd64 BuildDate=2024-11-06T11:22:34Z VendorInfo=gohugoio