### PR TITLE
Remove deprecated shortcode 'gist'

### DIFF
--- a/exampleSite/content/blogs/rich-content.md
+++ b/exampleSite/content/blogs/rich-content.md
@@ -12,17 +12,7 @@ description: ""
 toc: 
 ---
 
-Hugo ships with several [Built-in Shortcodes](https://gohugo.io/content-management/shortcodes/#use-hugo-s-built-in-shortcodes) for rich content, along with a [Privacy Config](https://gohugo.io/about/hugo-and-gdpr/) and a set of Simple Shortcodes that enable static and no-JS versions of various social media embeds.
-
-## Gist Simple Shortcode
-```
-{{</* gist spf13 7896402 "img.html" */>}}
-```
-<br>
-{{< gist spf13 7896402 "img.html" >}}
-<br>
-
-
+Hugo ships with several [Embedded Shortcodes](https://gohugo.io/content-management/shortcodes/#embedded) for rich content, along with a [Privacy Config](https://gohugo.io/about/privacy/#configuration) and a set of Simple Shortcodes that enable static and no-JS versions of various social media embeds.
 
 ## Twitter Simple Shortcode
 ```


### PR DESCRIPTION
This PR closes #218 by simply removing the deprecated `gist` shortcode from the blog page `Rich content`.

It also fixes two broken anchor links.