### PR TITLE
Fix: Remove misleading cursor styles (closes #214)

### DIFF
--- a/layouts/partials/sections/experience.html
+++ b/layouts/partials/sections/experience.html
@@ -49,10 +49,9 @@
                                                 
                                                 {{ if $job.info.content }}
                                                     <span class="p-2">
-                                                        <span 
-                                                            style="cursor: pointer;" 
-                                                            data-bs-toggle="tooltip" 
-                                                            data-bs-placement="top" 
+                                                        <span
+                                                            data-bs-toggle="tooltip"
+                                                            data-bs-placement="top"
                                                             data-bs-original-title={{$job.info.content}}
                                                         > 
                                                             <i class="fas fa-info-circle fa-xs"></i>

--- a/static/css/footer.css
+++ b/static/css/footer.css
@@ -14,7 +14,6 @@ footer a:hover {
 footer .card {
     background-color: var(--secondary-color) !important;
     border-radius: .75rem;
-    cursor: context-menu;
     overflow: hidden;
     border: none;
 }

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -119,14 +119,9 @@ header .navbar.animate {
     transition: box-shadow 0.3s;
 }
 
-#hero .image img:hover {
-    cursor: pointer;
-}
-
 #hero .image.animate img:hover {
     box-shadow: 0 0 11px rgb(15 80 100 / 20%);
     filter: contrast(1.2);
-    cursor: pointer;
 }
 
 #hero a.btn.social-icon {
@@ -485,17 +480,12 @@ header .navbar.animate {
 }
 
 #achievements .card {
-    cursor: context-menu;
     background-color: var(--secondary-color) !important;
     border-radius: 1rem;
     box-shadow: 0 0 36px rgba(0,0,0,0.1);
     /* transform: translate3d(0, 0, 0); */
     transition: box-shadow .2s linear,opacity .2s linear;
     border: 2px solid transparent;
-}
-
-#achievements a.card {
-    cursor: alias;
 }
 
 #achievements .card h5 {

--- a/static/css/list.css
+++ b/static/css/list.css
@@ -2,7 +2,6 @@
     background-color: var(--secondary-color) !important;
     box-shadow: 0px 8px 56px rgba(15, 80, 100, 0.16);
     border-radius: .75rem;
-    cursor: context-menu;
     overflow: hidden;
     border: none;
 }


### PR DESCRIPTION
Remove inappropriate cursor declarations that mislead users:
- cursor: context-menu from achievement, footer, and list cards
- cursor: alias from linked achievement cards
- cursor: pointer from hero image (not clickable)
- cursor: pointer from tooltip icon (hover-only, not clickable)

Kept functional cursors for non-semantic clickable elements:
- Experience tabs (<div> elements)
- Scroll-to-top buttons
- Gallery zoom-in indicator