### PR TITLE
feat: enable image-based icons in project links.

### DIFF
--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -371,6 +371,8 @@ params:
         links:
           - icon: fab fa-github
             url: https://github.com/gurusabarish/HugoProfileV2
+          - icon: /fav.png
+            url: https://hugo-profile-2.netlify.app
 
   #Contact
   contact:

--- a/layouts/partials/sections/projects.html
+++ b/layouts/partials/sections/projects.html
@@ -25,7 +25,13 @@
                         {{ range .links }}
                         <span class="m-1 mx-2">
                             <a href="{{ .url }}" target="_blank">
+                                {{ if or (in .icon "/") (hasSuffix .icon ".svg") (hasSuffix .icon ".png") (hasSuffix
+                                .icon ".jpg") (hasSuffix .icon ".webp") }}
+                                <img src="{{ .icon }}" alt="icon"
+                                    style="height: 1em; width: auto; vertical-align: -0.125em;">
+                                {{ else }}
                                 <i class="{{ .icon }}"></i>
+                                {{ end }}
                             </a>
                         </span>
                         {{ end }}
@@ -63,7 +69,13 @@
                         {{ range .Params.links }}
                         <span class="m-1 mx-2">
                             <a href="{{ .url }}">
+                                {{ if or (in .icon "/") (hasSuffix .icon ".svg") (hasSuffix .icon ".png") (hasSuffix
+                                .icon ".jpg") (hasSuffix .icon ".webp") }}
+                                <img src="{{ .icon }}" alt="icon"
+                                    style="height: 1em; width: auto; vertical-align: -0.125em;">
+                                {{ else }}
                                 <i class="{{ .icon }}"></i>
+                                {{ end }}
                             </a>
                         </span>
                         {{ end }}


### PR DESCRIPTION
## Feature
Enable image-based icons in project links.

- Simplify icon handling in the project section to make it more flexible.
- Local testing in `hugo server --source exampleSite --themesDir ../..`
- Modifying `exampleSite/hugo.yaml` to express this feature.

<img width="404" height="528" alt="image" src="https://github.com/user-attachments/assets/35a7311e-887d-4d98-80e2-1a961b51c453" />
