### PR TITLE
Fix broken images when project image is empty

### DIFF
--- a/layouts/partials/sections/projects.html
+++ b/layouts/partials/sections/projects.html
@@ -7,9 +7,11 @@
             {{ range $projects.items | default .Site.Params.projects.items }}
             <div class="col-lg-4 col-md-6 my-3">
                 <div class="card my-3 h-100" title="{{ .title }}">
+                    {{ if .image }}
                     <div class="card-head">
                         <img class="card-img-top" src="{{ .image }}" alt="{{ .title }}">
                     </div>
+                    {{ end }}
                     <div class="card-body bg-transparent p-3">
                         <div class="pb-2 bg-transparent">
                             {{ range .badges }}
@@ -46,9 +48,11 @@
             {{ if .Params.showInHome | default true }}
             <div class="col-lg-4 col-md-6 my-3">
                 <div class="card my-3 h-100" title="{{ .Title }}">
+                    {{ if .Params.image }}
                     <div class="card-head">
                         <img class="card-img-top" src="{{ .Params.image }}" alt="{{ .Title }}">
                     </div>
+                    {{ end }}
                     <div class="card-body bg-transparent p-3">
                         <div class="pb-2 bg-transparent">
                             {{ range .Params.badges }}

--- a/layouts/projects/list.html
+++ b/layouts/projects/list.html
@@ -17,9 +17,11 @@
         {{ range .Paginator.Pages }}
         <div class="col-lg-4 col-md-6 my-3">
             <div class="card my-3 h-100" title="{{ .Title }}">
+                {{ if .Params.image }}
                 <div class="card-head">
                     <img class="card-img-top" src="{{ .Params.image }}" alt="{{ .Title }}">
                 </div>
+                {{ end }}
                 <div class="card-body bg-transparent p-3">
                     <div class="pb-2 bg-transparent">
                         {{ range .Params.badges }}


### PR DESCRIPTION
When a project has `image: ""` or no image set, the template renders an <img> with an empty src, which resolves to the site's baseURL. This results in a broken/invisible 0x0 image that loads the homepage HTML as an image source.

This PR wraps the card-head image block in a conditional so the <img> element is only rendered when an image is actually provided.

Screenshots:

* Before: 
<img width="1327" height="652" alt="Capture d’écran 2026-03-25 à 09 57 31" src="https://github.com/user-attachments/assets/e2cc03e4-3321-42f4-97a2-0aa9c98218bb" />

* After: 
<img width="1327" height="652" alt="Capture d’écran 2026-03-25 à 09 59 05" src="https://github.com/user-attachments/assets/cfd8b7d9-ba97-4e73-9311-da7795a956a2" />
