### PR TITLE
Fix Keep consistency between recent posts and the blog list covers

### DIFF
--- a/static/css/list.css
+++ b/static/css/list.css
@@ -54,6 +54,7 @@
 
 #list-page .card > .card-header .card-img-top {
     width: 100%;
+    object-fit: cover;
     height: 250px !important;
     background-color: transparent !important;
 }


### PR DESCRIPTION
This is how the post's covers show in the recent post section
https://hugo-profile.netlify.app/

<img width="893" height="564" alt="image" src="https://github.com/user-attachments/assets/73fc1431-7f27-434d-a7e8-9a05e71e3733" />

While in the blog list, the images stretch
https://hugo-profile.netlify.app/blogs/

<img width="893" height="647" alt="image" src="https://github.com/user-attachments/assets/a65d783b-6d00-410f-9b2c-8b0550994999" />

So, to keep consistency I added the missing property. 😸 
