### PR TITLE
Fix: Replace deprecated Hugo language config and template methods (0.158.0+)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 ## Requirements
 
-- **Hugo version 0.87.0 or higher**   
+- **Hugo version 0.158.0 or higher**   
 To check your installed version, run:   
   ```bash
   hugo version

--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -1,5 +1,5 @@
 baseURL: "https://hugo-profile.netlify.app"
-languageCode: "en-us"
+locale: "en-us"
 title: "Hugo Profile"
 theme: hugo-profile
 
@@ -9,7 +9,7 @@ defaultContentLanguageInSubdir: false
 
 languages:
   en:
-    languageName: "English"
+    label: "English"
     weight: 1
     contentDir: "content"
     menu:
@@ -25,7 +25,7 @@ languages:
           url: /gallery
           weight: 2
   es:
-    languageName: "Español"
+    label: "Español"
     weight: 2
     contentDir: "content/es"
     menu:
@@ -232,7 +232,7 @@ languages:
         btnName: Escríbeme
   fr:
     contentDir: "content/fr"
-    languageName: "Français"
+    label: "Français"
     weight: 3
     menu:
       main:

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -31,7 +31,7 @@
 <!-- Multilingual SEO -->
 {{ if hugo.IsMultilingual }}
   {{ range .AllTranslations }}
-    <link rel="alternate" hreflang="{{ .Language.Lang }}" href="{{ .Permalink }}" title="{{ .Language.LanguageName }}">
+    <link rel="alternate" hreflang="{{ .Language.Lang }}" href="{{ .Permalink }}" title="{{ .Language.Label }}">
   {{ end }}
   <!-- OpenGraph locale -->
   <meta property="og:locale" content="{{ .Language.Lang }}">

--- a/layouts/partials/sections/language-switcher.html
+++ b/layouts/partials/sections/language-switcher.html
@@ -4,7 +4,7 @@
         data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         {{ with .Language }}
             🌐
-            <span class="d-none d-md-inline">{{ .LanguageName }}</span>
+            <span class="d-none d-md-inline">{{ .Label }}</span>
         {{ end }}
     </a>
     <div class="dropdown-menu shadow-lg rounded" aria-labelledby="languageDropdown">
@@ -15,8 +15,8 @@
             {{- range site.Home.AllTranslations -}}
             <a class="dropdown-item text-center nav-link{{ if eq .Language.Lang $.Language.Lang }} active{{ end }}" 
                href="{{ .RelPermalink }}" 
-               title="{{ .Language.LanguageName }}">
-                {{ .Language.LanguageName }}
+               title="{{ .Language.Label }}">
+                {{ .Language.Label }}
             </a>
             {{- end -}}
         {{- else -}}
@@ -24,8 +24,8 @@
             {{- range $translations -}}
             <a class="dropdown-item text-center nav-link{{ if eq .Language.Lang $.Language.Lang }} active{{ end }}" 
                href="{{ .RelPermalink }}" 
-               title="{{ .Language.LanguageName }}">
-                {{ .Language.LanguageName }}
+               title="{{ .Language.Label }}">
+                {{ .Language.Label }}
             </a>
             {{- end -}}
         {{- end -}}

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,9 +1,9 @@
 [build]
 publish = "exampleSite/public"
-command = 'cd exampleSite && echo -e "\ngoogleAnalytics: $GOOGLE_ANALYTICS \ndisqusShortname: $DISQUS_SHORTNAME \n" >> config.yaml && hugo --gc --minify --themesDir ../..'
+command = 'cd exampleSite && printf "\nservices:\n  googleAnalytics:\n    id: %s\n  disqus:\n    shortname: %s\n" "$GOOGLE_ANALYTICS" "$DISQUS_SHORTNAME" >> hugo.yaml && hugo --gc --minify --themesDir ../..'
 
 [context.production.environment]
-HUGO_VERSION = "0.143.0"
+HUGO_VERSION = "0.161.1"
 HUGO_ENV = "production"
 HUGO_ENABLEGITINFO = "true"
 HUGO_THEME = "repo"
@@ -12,7 +12,7 @@ HUGO_THEME = "repo"
 command = "cd exampleSite && hugo --gc --minify --enableGitInfo --themesDir ../.."
 
 [context.split1.environment]
-HUGO_VERSION = "0.143.0"
+HUGO_VERSION = "0.161.1"
 HUGO_ENV = "production"
 HUGO_THEME = "repo"
 
@@ -20,14 +20,14 @@ HUGO_THEME = "repo"
 command = "cd exampleSite && hugo --gc --minify --buildFuture --themesDir ../.. -b $DEPLOY_PRIME_URL"
 
 [context.deploy-preview.environment]
-HUGO_VERSION = "0.143.0"
+HUGO_VERSION = "0.161.1"
 HUGO_THEME = "repo"
 
 [context.branch-deploy]
 command = "cd exampleSite && hugo --gc --minify --themesDir ../.. -b $DEPLOY_PRIME_URL"
 
 [context.branch-deploy.environment]
-HUGO_VERSION = "0.143.0"
+HUGO_VERSION = "0.161.1"
 
 [context.next.environment]
 HUGO_ENABLEGITINFO = "true"

--- a/theme.toml
+++ b/theme.toml
@@ -5,7 +5,7 @@ description = "A high performance and mobile first hugo template for personal po
 homepage = "https://github.com/gurusabarish/hugo-profile"
 demosite = "https://hugo-profile.netlify.app"
 tags = ["Responsive","Blog", "Portfolio", "Personal"]
-min_version = "0.68.0"
+min_version = "0.158.0"
 
 [author]
   name = "Gurusabarish"


### PR DESCRIPTION
## Summary

Replaces deprecated Hugo language configuration keys and template methods that produce deprecation warnings in Hugo 0.158.0+ and will be removed in a future release.

### Changes

**`exampleSite/hugo.yaml`**
- `languageCode: "en-us"` → `locale: "en-us"` (top-level config)
- `languageName: "English"` → `label: "English"` (languages.en)
- `languageName: "Español"` → `label: "Español"` (languages.es)
- `languageName: "Français"` → `label: "Français"` (languages.fr)

**`layouts/partials/head.html`**
- `.Language.LanguageName` → `.Language.Label`

**`layouts/partials/sections/language-switcher.html`**
- `.LanguageName` → `.Label`
- `.Language.LanguageName` → `.Language.Label` (×4 occurrences)

**`theme.toml`**
- `min_version = "0.68.0"` → `min_version = "0.158.0"`

**`README.md`**
- Hugo version requirement: `0.87.0` → `0.158.0`

### References

- Hugo deprecation notice: https://discourse.gohugo.io/t/deprecations-in-v0-158-0/56869
- Hugo releases: https://github.com/gohugoio/hugo/releases/tag/v0.158.0

## Test plan

- [ ] Build the exampleSite with Hugo 0.158.0+ and confirm no deprecation warnings are emitted for language config
- [ ] Verify the language switcher dropdown still displays language names correctly
- [ ] Verify `<link rel="alternate">` hreflang tags still render correctly in page `<head>`
- [ ] Confirm the site builds cleanly on Hugo 0.161.1