### PR TITLE
Hugo Deprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,13 +126,16 @@ defaultContentLanguageInSubdir: false
 
 languages:
   en:
-    languageName: "English"
+    locale: "en-US"
+    label: "English"
     weight: 1
   es:
-    languageName: "Español"
+    locale: "es-ES"
+    label: "Español"
     weight: 2
   fr:
-    languageName: "Français"
+    locale: "fr-FR"
+    label: "Français"
     weight: 3
 ```
 
@@ -166,7 +169,8 @@ To add support for a new language (e.g., German):
    ```yaml
    languages:
      de:
-       languageName: "Deutsch"
+       locale: "nl-NL"
+       label: "Deutsch"
        weight: 4
    ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hugo Profile
 
-[![Twitter](https://img.shields.io/twitter/url?label=Tweet&style=social&url=https%3A%2F%2Fgithub.com%2Fgurusabarish%2Fhugo-profile)](https://twitter.com/intent/tweet?text=Wow:&url=https%3A%2F%2Fgithub.com%2Fgurusabarish%2Fhugo-profile) [![GitHub forks](https://img.shields.io/github/forks/gurusabarish/hugo-profile?style=plastic)](https://github.com/gurusabarish/hugo-profile/network) [![GitHub stars](https://img.shields.io/github/stars/gurusabarish/hugo-profile?style=plastic)](https://github.com/gurusabarish/hugo-profile/stargazers)
+[![Twitter](https://img.shields.io/twitter/url?label=Tweet&style=social&url=https%3A%2F%2Fgithub.com%2Fgurusabarish%2Fhugo-profile)](https://x.com/intent/tweet?text=Wow:&url=https%3A%2F%2Fgithub.com%2Fgurusabarish%2Fhugo-profile) [![GitHub forks](https://img.shields.io/github/forks/gurusabarish/hugo-profile?style=plastic)](https://github.com/gurusabarish/hugo-profile/network) [![GitHub stars](https://img.shields.io/github/stars/gurusabarish/hugo-profile?style=plastic)](https://github.com/gurusabarish/hugo-profile/stargazers)
 
 [![Netlify Status](https://api.netlify.com/api/v1/badges/5c1dcb34-cada-4c80-82b7-cfdbdbd7c774/deploy-status)](https://app.netlify.com/sites/hugo-profile/deploys)
 ![Latest Release](https://img.shields.io/github/v/release/gurusabarish/hugo-profile?include_prereleases)
@@ -219,11 +219,11 @@ rm -rf public/ && hugo
 ## Trouble-Shooting
 
 ```
-ERROR error calling resources.GetRemote: Get "https://publish.twitter.com/oembed?dnt=false&url=https%3A%2F%2Ftwitter.com%2FGoHugoIO%2Fstatus%2F1315233626070503424": net/http: TLS handshake timeout
+ERROR error calling resources.GetRemote: Get "https://publish.x.com/oembed?dnt=false&url=https%3A%2F%x.com%2FGoHugoIO%2Fstatus%2F1315233626070503424": net/http: TLS handshake timeout
 Built in 10266 ms
 Error: error building site: logged 1 error(s)
 ```
-The TLS handshake timeout error can happen due to network issues. If this error persists, you can delete the shortcode example `{{< tweet user="GoHugoIO" id="1315233626070503424" >}}` in the "content/blogs/rich-content.md" file.
+The TLS handshake timeout error can happen due to network issues. If this error persists, you can delete the shortcode example `{{< x user="GoHugoIO" id="1315233626070503424" >}}` in the "content/blogs/rich-content.md" file.
 
 
 ## Issues

--- a/exampleSite/README.md
+++ b/exampleSite/README.md
@@ -19,7 +19,7 @@
 [static site generator]: https://en.wikipedia.org/wiki/Static_site_generator
 [support]: https://discourse.gohugo.io
 [themes]: https://themes.gohugo.io/
-[twitter]: https://twitter.com/gohugoio
+[twitter]: https://x.com/gohugoio
 [website]: https://gohugo.io
 [windows]: https://gohugo.io/installation/windows
 

--- a/exampleSite/content/blogs/rich-content.md
+++ b/exampleSite/content/blogs/rich-content.md
@@ -16,10 +16,10 @@ Hugo ships with several [Embedded Shortcodes](https://gohugo.io/content-manageme
 
 ## X Simple Shortcode
 ```
-{{</* tweet user="GoHugoIO" id="1315233626070503424" */>}}
+{{</* x user="GoHugoIO" id="1315233626070503424" */>}}
 ```
 <br>
-{{< tweet user="GoHugoIO" id="1315233626070503424" >}}
+{{< x user="GoHugoIO" id="1315233626070503424" >}}
 <br>
 
 

--- a/exampleSite/content/es/blogs/rich-content.md
+++ b/exampleSite/content/es/blogs/rich-content.md
@@ -16,7 +16,7 @@ Hugo viene con varios [Shortcodes Integrados](https://gohugo.io/content-manageme
 
 ## Shortcode Simple de X
 ```
-{{</* tweet user="GoHugoIO" id="1315233626070503424" */>}}
+{{</* x user="GoHugoIO" id="1315233626070503424" */>}}
 ```
 <br>
 <!-- Temporarily removed for build -->

--- a/exampleSite/content/fr/blogs/rich-content.md
+++ b/exampleSite/content/fr/blogs/rich-content.md
@@ -16,7 +16,7 @@ Hugo est livré avec plusieurs [Shortcodes Intégrés](https://gohugo.io/content
 
 ## Shortcode Simple X
 ```
-{{</* tweet user="GoHugoIO" id="1315233626070503424" */>}}
+{{</* x user="GoHugoIO" id="1315233626070503424" */>}}
 ```
 <br>
 <!-- Temporarily removed for build -->

--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -185,7 +185,7 @@ languages:
               - icon: fab fa-github
                 url: https://github.com/gurusabarish/hugo-profile
               - icon: fab fa-twitter
-                url: https://twitter.com/intent/tweet?text=Échale+un+vistazo:&url=https%3A%2F%2Fgithub.com%2Fgurusabarish%2Fhugo-profile
+                url: https://x.com/intent/tweet?text=Échale+un+vistazo:&url=https%3A%2F%2Fgithub.com%2Fgurusabarish%2Fhugo-profile
           - title: Conversor de Imágenes
             content: Una aplicación web para convertir imágenes a pdf, png a jpg, png a jpg y png a webp sin base de datos usando django.
             image: /images/projects/converter.jpg
@@ -392,7 +392,7 @@ languages:
               - icon: fab fa-github
                 url: https://github.com/gurusabarish/hugo-profile
               - icon: fab fa-twitter
-                url: https://twitter.com/intent/tweet?text=Découvrez-le:&url=https%3A%2F%2Fgithub.com%2Fgurusabarish%2Fhugo-profile
+                url: https://x.com/intent/tweet?text=Découvrez-le:&url=https%3A%2F%2Fgithub.com%2Fgurusabarish%2Fhugo-profile
           - title: Convertisseur d'Images
             content: Une application web pour convertir des images en pdf, png en jpg, png en jpg et png en webp sans base de données en utilisant django.
             image: /images/projects/converter.jpg
@@ -775,7 +775,7 @@ params:
           - icon: fab fa-github
             url: https://github.com/gurusabarish/hugo-profile
           - icon: fab fa-twitter
-            url: https://twitter.com/intent/tweet?text=Check+it+out:&url=https%3A%2F%2Fgithub.com%2Fgurusabarish%2Fhugo-profile
+            url: https://x.com/intent/tweet?text=Check+it+out:&url=https%3A%2F%2Fgithub.com%2Fgurusabarish%2Fhugo-profile
 
       - title: Image Converter
         content: A web app to convert image to pdf, png to jpg, png to jpg and png to webp without database using django.
@@ -828,7 +828,7 @@ params:
     socialNetworks:
       github: https://github.com
       linkedin: https://linkedin.com
-      twitter: https://twitter.com
+      x: https://x.com
       instagram: https://instagram.com
       facebook: https://facebook.com
 

--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -9,7 +9,8 @@ defaultContentLanguageInSubdir: false
 
 languages:
   en:
-    languageName: "English"
+    locale: "en-US"
+    label: "English"
     weight: 1
     contentDir: "content"
     menu:
@@ -25,7 +26,8 @@ languages:
           url: /gallery
           weight: 2
   es:
-    languageName: "Español"
+    locale: "es-ES"
+    label: "Español"
     weight: 2
     contentDir: "content/es"
     menu:
@@ -231,8 +233,9 @@ languages:
         content: Mi bandeja de entrada siempre está abierta. Ya sea que tengas una pregunta o simplemente quieras saludar, ¡haré todo lo posible para responderte!
         btnName: Escríbeme
   fr:
+    locale: "fr-FR"
+    label: "Français"
     contentDir: "content/fr"
-    languageName: "Français"
     weight: 3
     menu:
       main:

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -80,7 +80,7 @@
                   </a>
                 </li>
                 <li class="list-inline-item text-center">
-                  <a target="_blank" href='https://twitter.com/share?text={{ .Title }}&url={{ .Site.Params.hostName }}{{ .Permalink | absURL }}&hashtags={{ delimit .Params.tags "," }}'>
+                  <a target="_blank" href='https://x.com/share?text={{ .Title }}&url={{ .Site.Params.hostName }}{{ .Permalink | absURL }}&hashtags={{ delimit .Params.tags "," }}'>
                     <i class="fab fa-twitter"></i>
                   </a>
                 </li>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -31,7 +31,7 @@
 <!-- Multilingual SEO -->
 {{ if hugo.IsMultilingual }}
   {{ range .AllTranslations }}
-    <link rel="alternate" hreflang="{{ .Language.Lang }}" href="{{ .Permalink }}" title="{{ .Language.LanguageName }}">
+    <link rel="alternate" hreflang="{{ .Language.Lang }}" href="{{ .Permalink }}" title="{{ .Language.Label }}">
   {{ end }}
   <!-- OpenGraph locale -->
   <meta property="og:locale" content="{{ .Language.Lang }}">

--- a/layouts/partials/sections/footer/socialNetwork.html
+++ b/layouts/partials/sections/footer/socialNetwork.html
@@ -41,7 +41,7 @@
     {{ end }}
 
     {{ if .Site.Params.footer.socialNetworks.twitter }}
-    <a href="{{ .Site.Params.footer.socialNetworks.twitter }}" target="_blank" aria-label="twitter">
+    <a href="{{ .Site.Params.footer.socialNetworks.twitter }}" target="_blank" aria-label="x">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48px" height="48px">
             <path fill="#03a9f4"
                 d="M42,37c0,2.762-2.239,5-5,5H11c-2.762,0-5-2.238-5-5V11c0-2.762,2.238-5,5-5h26c2.761,0,5,2.238,5,5 V37z" />

--- a/layouts/partials/sections/language-switcher.html
+++ b/layouts/partials/sections/language-switcher.html
@@ -4,7 +4,7 @@
         data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         {{ with .Language }}
             🌐
-            <span class="d-none d-md-inline">{{ .LanguageName }}</span>
+            <span class="d-none d-md-inline">{{ .Label }}</span>
         {{ end }}
     </a>
     <div class="dropdown-menu shadow-lg rounded" aria-labelledby="languageDropdown">
@@ -15,8 +15,8 @@
             {{- range site.Home.AllTranslations -}}
             <a class="dropdown-item text-center nav-link{{ if eq .Language.Lang $.Language.Lang }} active{{ end }}" 
                href="{{ .RelPermalink }}" 
-               title="{{ .Language.LanguageName }}">
-                {{ .Language.LanguageName }}
+               title="{{ .Language.Label }}">
+                {{ .Language.Label }}
             </a>
             {{- end -}}
         {{- else -}}
@@ -24,8 +24,8 @@
             {{- range $translations -}}
             <a class="dropdown-item text-center nav-link{{ if eq .Language.Lang $.Language.Lang }} active{{ end }}" 
                href="{{ .RelPermalink }}" 
-               title="{{ .Language.LanguageName }}">
-                {{ .Language.LanguageName }}
+               title="{{ .Language.Label }}">
+                {{ .Language.Label }}
             </a>
             {{- end -}}
         {{- end -}}

--- a/layouts/shortcodes/gist.html
+++ b/layouts/shortcodes/gist.html
@@ -1,0 +1,1 @@
+<script src="https://gist.github.com/{{ .Get 0 }}/{{ .Get 1 }}.js{{ with .Get 2 }}?file={{ . | urlquery }}{{ end }}"></script>

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ publish = "exampleSite/public"
 command = 'cd exampleSite && echo -e "\ngoogleAnalytics: $GOOGLE_ANALYTICS \ndisqusShortname: $DISQUS_SHORTNAME \n" >> config.yaml && hugo --gc --minify --themesDir ../..'
 
 [context.production.environment]
-HUGO_VERSION = "0.143.0"
+HUGO_VERSION = "0.158.0"
 HUGO_ENV = "production"
 HUGO_ENABLEGITINFO = "true"
 HUGO_THEME = "repo"
@@ -12,7 +12,7 @@ HUGO_THEME = "repo"
 command = "cd exampleSite && hugo --gc --minify --enableGitInfo --themesDir ../.."
 
 [context.split1.environment]
-HUGO_VERSION = "0.143.0"
+HUGO_VERSION = "0.158.0"
 HUGO_ENV = "production"
 HUGO_THEME = "repo"
 
@@ -20,14 +20,14 @@ HUGO_THEME = "repo"
 command = "cd exampleSite && hugo --gc --minify --buildFuture --themesDir ../.. -b $DEPLOY_PRIME_URL"
 
 [context.deploy-preview.environment]
-HUGO_VERSION = "0.143.0"
+HUGO_VERSION = "0.158.0"
 HUGO_THEME = "repo"
 
 [context.branch-deploy]
 command = "cd exampleSite && hugo --gc --minify --themesDir ../.. -b $DEPLOY_PRIME_URL"
 
 [context.branch-deploy.environment]
-HUGO_VERSION = "0.143.0"
+HUGO_VERSION = "0.158.0"
 
 [context.next.environment]
 HUGO_ENABLEGITINFO = "true"

--- a/theme.toml
+++ b/theme.toml
@@ -5,7 +5,7 @@ description = "A high performance and mobile first hugo template for personal po
 homepage = "https://github.com/gurusabarish/hugo-profile"
 demosite = "https://hugo-profile.netlify.app"
 tags = ["Responsive","Blog", "Portfolio", "Personal"]
-min_version = "0.68.0"
+min_version = "0.158.0"
 
 [author]
   name = "Gurusabarish"


### PR DESCRIPTION
This resolves 3 separate issues with newer versions of Hugo, effectively making the minimum Hugo version 0.158.0:

1. Replacing instance of languageName with label.
   1. https://github.com/gohugoio/hugo/releases/tag/v0.158.0
1. Added the gist shortcode
   1. https://github.com/gohugoio/hugo/releases/tag/v0.143.0
1. Replacing an instance of twitter, tweet, or twitter_simple shortcodes with x
   1. https://github.com/gohugoio/hugo/releases/tag/v0.141.0
   1. Also replaced any URL instance of twitter.com with x.com